### PR TITLE
Fix typo in URLSpec.__init__ docstring

### DIFF
--- a/tornado/routing.py
+++ b/tornado/routing.py
@@ -605,7 +605,7 @@ class URLSpec(Rule):
         * ``pattern``: Regular expression to be matched. Any capturing
           groups in the regex will be passed in to the handler's
           get/post/etc methods as arguments (by keyword if named, by
-          position if unnamed. Named and unnamed capturing groups may
+          position if unnamed. Named and unnamed capturing groups
           may not be mixed in the same rule).
 
         * ``handler``: `~.web.RequestHandler` subclass to be invoked.


### PR DESCRIPTION
`may may not` -> `may not`